### PR TITLE
Add explicit USER instruction to Dockerfile (APPSEC-106883)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,3 +70,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - \
 # Configure Claude Code to use AWS Bedrock
 ENV CLAUDE_CODE_USE_BEDROCK=1
 ENV AWS_REGION=us-west-2
+
+# Run as the non-root runner user. This is already the base image default
+# (note the sudo on every RUN above); making it explicit satisfies the
+# Checkmarx KICS "Missing User Instruction" check (APPSEC-106883).
+USER runner


### PR DESCRIPTION
## What

Adds an explicit `USER runner` instruction to the runtime stage of the Dockerfile.

## Why

Checkmarx KICS (APPSEC-106883) flags the Dockerfile for a *Missing User Instruction* — "Always set a user in the runtime stage of your Dockerfile. Without it, the container defaults to root."

In practice this container **already runs as the non-root `runner` user**: the `ghcr.io/actions/actions-runner` base image sets that user, which is why every `RUN` in this file uses `sudo` and `PATH`/`HOME` point at `/home/runner/...`. So this change is behaviorally a no-op — it just makes the existing default explicit so the scanner can see it, with zero risk to the build.

## Ticket

https://moveinc.atlassian.net/browse/APPSEC-106883

🤖 Generated with [Claude Code](https://claude.com/claude-code)